### PR TITLE
Dont setup the ports until the docker container is being configured.

### DIFF
--- a/core/testcontainers-redis/src/main/java/com/redis/testcontainers/RedisClusterContainer.java
+++ b/core/testcontainers-redis/src/main/java/com/redis/testcontainers/RedisClusterContainer.java
@@ -1,7 +1,8 @@
 package com.redis.testcontainers;
 
-import java.util.Objects;
 
+import com.redis.testcontainers.RedisServer;
+import java.util.Objects;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
@@ -27,7 +28,7 @@ public class RedisClusterContainer extends GenericContainer<RedisClusterContaine
 	private int slavesPerMaster = DEFAULT_SLAVES_PER_MASTER;
 
 	/**
-	 * @deprecated use {@link RedisClusterContainer(DockerImageName)} instead
+	 * @deprecated use {@link RedisClusterContainer (DockerImageName)} instead
 	 */
 	@Deprecated
 	public RedisClusterContainer() {
@@ -37,8 +38,14 @@ public class RedisClusterContainer extends GenericContainer<RedisClusterContaine
 	public RedisClusterContainer(DockerImageName dockerImageName) {
 		super(dockerImageName);
 		withIP(DEFAULT_IP);
-		update();
 		waitingFor(Wait.forLogMessage(".*Cluster state changed: ok*\\n", 1));
+	}
+
+	// This is called in the GenericContainer before the container is started to configure itself.
+	// At this point we call update to setup the environment variables and ports.
+	@Override
+	protected void configure() {
+		update();
 	}
 
 	@Override
@@ -93,7 +100,7 @@ public class RedisClusterContainer extends GenericContainer<RedisClusterContaine
 			throw new IllegalArgumentException("Count must be greater than zero");
 		}
 		this.masters = count;
-		return update();
+		return this;
 	}
 
 	public RedisClusterContainer withSlavesPerMaster(int count) {
@@ -101,12 +108,12 @@ public class RedisClusterContainer extends GenericContainer<RedisClusterContaine
 			throw new IllegalArgumentException("Count must be zero or greater");
 		}
 		this.slavesPerMaster = count;
-		return update();
+		return this;
 	}
 
 	public RedisClusterContainer withInitialPort(int port) {
 		this.initialPort = port;
-		return update();
+		return this;
 	}
 
 	@Override


### PR DESCRIPTION
Fixes https://github.com/redis-developer/testcontainers-redis/issues/4
Before on the constructor it would call update, and this would add fixed exposed ports, locking in port 7000. 
I removed the update in the constructor and moved it to the configure method inherited from `GenericContainer`. 

When you start the  docker container it calls the method `protected void configure()`
https://github.com/testcontainers/testcontainers-java/blob/3b7c2ebca73988b484a0bcdb339e7f04df016a41/core/src/main/java/org/testcontainers/containers/GenericContainer.java#L335

So we override the method and call update to setup the ports. This way we know everything has been set and we wont add any extra ports. 