### PR TITLE
Manage testcontainers version independently

### DIFF
--- a/core/testcontainers-redis/testcontainers-redis.gradle
+++ b/core/testcontainers-redis/testcontainers-redis.gradle
@@ -1,3 +1,5 @@
+ext['testcontainers.version'] = "$testcontainersVersion"
+
 dependencies {
     api 'org.testcontainers:testcontainers'
     api group: 'com.redis', name: 'redis-enterprise-admin', version: adminVersion

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,7 @@ jacocoVersion              = 0.8.11
 kordampBuildVersion        = 3.4.0
 kordampPluginVersion       = 0.54.0
 springBootVersion          = 3.2.3
+testcontainersVersion      = 1.19.7
 
 adminVersion               = 0.6.0
 lettucemodVersion          = 3.7.3


### PR DESCRIPTION
Currently, testcontainers version depends on spring boot dependency.
This commit introduces a new property to manage testcontainers version.
